### PR TITLE
Add Conduit8 - CLI registry for Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Composio](https://composio.dev/)** - An open-source toolset designed for building and managing AI Agents and LLMs.
 
-**[Conduit8](https://github.com/conduit8/conduit8)** - A CLI registry for discovering, installing, and managing Claude Code skills with one-command installation directly to ~/.claude/skills/.
+**[Conduit8](https://conduit8.dev)** - A CLI registry for discovering, installing, and managing Claude Code skills with one-command installation directly to ~/.claude/skills/.
 
 **[Continue](https://continue.dev/)** - An open-source autopilot for software development that integrates with VS Code and JetBrains, allowing customizable LLM integration for code generation, editing, and debugging.
 


### PR DESCRIPTION
## Description

Adds [Conduit8](https://github.com/conduit8/conduit8) to the alphabetically organized tool list.

## What is Conduit8?

Conduit8 is a CLI registry for discovering, installing, and managing Claude Code skills. It provides:
- Search 20+ curated skills by keyword or category
- One-command installation directly to ~/.claude/skills/
- CLI-based skill management (list, remove)
- Like npm/pip for Claude Code skills

## Placement

Added alphabetically between **Composio** and **Continue** in the main tool list.

## Installation

```bash
npx conduit8 search skills
npx conduit8 install skill <name>
```

## Website

https://conduit8.dev

## License

AGPL-3.0