### PR TITLE
Add toprank — SEO + Google Ads plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Theia IDE](https://theia-ide.org/#theiaide)** - An extensible open-source IDE (web and desktop) with Theia Coder, an AI-powered coding agent that can browse workspaces, propose code changes, and automatically detect and fix issues, with Edit Mode and Agent Mode options.
 
+**[toprank](https://github.com/nowork-studio/toprank)** - An open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, ship meta tag and schema markup fixes, and manage ad campaigns directly from Claude Code.
+
 **[Traceloop](https://traceloop.com/)** - A tool that uses OpenTelemetry tracing data with generative AI to improve system reliability.
 
 **[Trag](https://usetrag.com/)** - An AI-powered code review tool with customizable patterns and pre-defined instructions.


### PR DESCRIPTION
Adds **toprank** to the Tools list (alphabetical order, between Theia IDE and Traceloop).

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, then ships fixes — meta tag rewrites, JSON-LD schema markup, keyword bid adjustments — directly to source code or CMS (WordPress, Strapi, Contentful, Ghost).

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 100+ stars, actively maintained with CHANGELOG, tests, and eval harness