### PR TITLE
Add Burnd — local-first Claude Code cost-leak CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[BitBuilder](https://www.bitbuilder.ai/)** - A GitHub integration for generating pull requests directly from issues using AI.
 
+**[Burnd](https://github.com/garvitsurana/burnd)** - A local-first CLI for Claude Code power users that parses ~/.claude/projects/*.jsonl session files and runs cost-leak detectors (retry storms, tool overuse, repeated reads, thrash, tired-coding) to show which patterns are driving spend. npx-installable, MIT, zero telemetry.
+
 **[Blackbox AI](https://www.useblackbox.io/)** - An AI coding assistant available as a VS Code extension and web interface, offering autocomplete, chat, and links to online coding references.
 
 **[Blinky Debugging Agent](https://github.com/seahyinghang8/blinky)** - A debugging agent for VS Code that helps identify and fix backend errors, inspired by SWE-agent.


### PR DESCRIPTION
Adds Burnd alphabetically (between BitBuilder and Blackbox AI).

Why it fits this list specifically: the About section calls out 'Productivity Enhancement — AI-powered tools that boost developer efficiency.' Burnd targets the efficiency leak most Claude Code users don't see: they pay for Claude Pro/Max but their own tool-use patterns burn the quota. Burnd reads local session logs and runs detectors that pinpoint the expensive patterns (retry storms, tool overuse, repeated reads, thrash), so users can course-correct instead of just paying more.

- Repo: https://github.com/garvitsurana/burnd
- npm: getburnd
- MIT, local-first, npx-installable.