### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[agentskill.sh](https://agentskill.sh)** - A directory of 44k+ skills for Claude Code, Cursor, and Codex with two-layer security scanning and one-command installation via the `/learn` skill.
 
+**[agenttrace](https://github.com/luoyuctl/agenttrace)** - A local-first TUI for inspecting AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs, surfacing cost, cache usage, failures, latency, anomalies, health gates, and diffs.
+
 **[Aider](https://aider.chat/)** - An open-source AI pair programming tool that works directly in your terminal, offering Git integration, multi-file editing, and natural language commands for code generation, debugging, refactoring, and automated commits.
 
 **[AI Code Convert](https://aicodeconvert.com/)** - A web-based tool for translating code between programming languages using AI.


### PR DESCRIPTION
Adds agenttrace as a local-first TUI for inspecting AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs.\n\nIt fits the developer-tooling list by surfacing cost, cache usage, failures, latency, anomalies, health gates, and session diffs for AI coding workflows.