### PR TITLE
Add TinyTools — free browser-based AI dev utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[toprank](https://github.com/nowork-studio/toprank)** - An open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, ship meta tag and schema markup fixes, and manage ad campaigns directly from Claude Code.
 
+**[TinyTools](https://tinytools-smoky.vercel.app/)** - A collection of free browser-based developer utilities including an AI Cost Calculator for comparing LLM pricing, an AI Robots.txt Generator for LLM crawlers, an AI Content Disclosure Generator (EU AI Act Article 50 compliant), an AI Background Remover that runs locally via WebAssembly, plus OG image, favicon, color palette, and SEO meta tag generators. No signup, open source.
+
 **[Traceloop](https://traceloop.com/)** - A tool that uses OpenTelemetry tracing data with generative AI to improve system reliability.
 
 **[Trag](https://usetrag.com/)** - An AI-powered code review tool with customizable patterns and pre-defined instructions.


### PR DESCRIPTION
Hi! Adding **TinyTools** in alphabetical order (between Theia IDE and Traceloop).

TinyTools is a collection of free, browser-based developer utilities, several of which use AI:

- **AI Cost Calculator** — compare LLM provider token pricing
- **AI Robots.txt Generator** — robots.txt rules for LLM crawlers (GPTBot, ClaudeBot, etc.)
- **AI Content Disclosure Generator** — EU AI Act Article 50 compliant disclosures
- **AI Background Remover** — runs locally via WebAssembly
- Plus OG image, favicon, color palette, SEO meta tag, and domain name generators

All tools are browser-based, no signup, and the project is open source. Live at https://tinytools-smoky.vercel.app/

Thanks for maintaining this list!