### PR TITLE
Add SprintFlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Sourcegraph Cody](https://sourcegraph.com/cody)** - An AI assistant with deep codebase understanding, offering chat, refactoring, and code generation with enterprise features.
 
+**[SprintFlint](https://sprintflint.com)** - A sprint-native Jira alternative for small engineering teams with AI-assisted story import, GitHub PR ↔ ticket sync, sprint forecasting, and a native MCP server for Claude Code, Cursor, and Zed.
+
 **[SQLAI.ai](https://www.sqlai.ai/)** - An AI tool for SQL query generation, optimization, and explanation, with the ability to train on database schemas.
 
 **[Srcbook](https://srcbook.com/)** - A TypeScript-centric app development platform with an AI app builder and TypeScript notebook.


### PR DESCRIPTION
Hi! Submitting [SprintFlint](https://sprintflint.com) for the AI dev tools list.

**What it is:** A sprint-native Jira alternative built for small engineering teams (5–30 devs). The AI angle is genuine — not bolt-on:

- **AI story import** — paste a meeting note, brain-dump, or product brief; SprintFlint structures it into tickets, sequences them, and assigns story points
- **Native MCP server** — `mcp.sprintflint.com` works directly in Claude Code, Cursor, and Zed without bridging tools
- **Autoplay** — hands an open ticket to Claude with full repo context; ships a PR linked back to the ticket
- **PR ↔ ticket sync** — review-requested-changes bounces ticket back to in-progress automatically; merged PR closes the ticket
- **Sprint forecasting** — uses team velocity history to flag overcommitted sprints before they start

Inserted alphabetically between Sourcegraph Cody and SQLAI.ai. Happy to adjust description length / position if it doesn't fit your preferred format.

Thanks for maintaining this list!