### PR TITLE
Add AgentTier (alphabetical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[agentskill.sh](https://agentskill.sh)** - A directory of 44k+ skills for Claude Code, Cursor, and Codex with two-layer security scanning and one-command installation via the `/learn` skill.
 
+**[AgentTier](https://github.com/agenttier/agenttier)** - Self-hosted Kubernetes-native sandbox runtime for AI coding agents (Claude Code, OpenHands, LangGraph). Each Sandbox CRD provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation, hierarchical governance, and a streaming agent-mode REST API.
+
 **[agenttrace](https://github.com/luoyuctl/agenttrace)** - A local-first TUI for inspecting AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs, surfacing cost, cache usage, failures, latency, anomalies, health gates, and diffs.
 
 **[Aider](https://aider.chat/)** - An open-source AI pair programming tool that works directly in your terminal, offering Git integration, multi-file editing, and natural language commands for code generation, debugging, refactoring, and automated commits.


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) to the alphabetical Tools list.

AgentTier is a self-hosted Kubernetes-native sandbox runtime for AI coding agents and human developers. Each `Sandbox` CRD provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation. It supports both interactive use (browser terminal over WebSocket) and headless agent workloads (REST `/configure` to install agent code, then SSE-streaming `/invoke` to run). Reference templates ship for Claude Code + AWS Bedrock, OpenHands, and a model-free LangGraph agent. Apache-2.0.

Format matches the project's `**[Name](url)** - Description.` style. Alphabetically placed between `agentskill.sh` and `agenttrace`. Single-line addition.

Disclosure: I'm a contributor to AgentTier.
