### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[CodexAtlas](https://codedocumentation.app/)** - An automated code and API documentation tool that uses the latest AI models.
 
+**[codex-profiles](https://github.com/Ducksss/codex-profiles)** - An open-source MIT Bash CLI helper for switching OpenAI Codex CLI/Desktop accounts using isolated `CODEX_HOME` profiles, with Homebrew install and no token copying.
+
 **[CodeWP](https://codewp.ai/)** - AI tools specifically trained for WordPress developers, offering code generation for snippets and plugins.
 
 **[Command Code](https://commandcode.ai/)** - A CLI-based AI coding agent that learns a developer's coding style, supports multiple LLM providers, and can build features, fix bugs, write tests, refactor code, and generate commits or pull requests.


### PR DESCRIPTION
## Summary

Adds `codex-profiles`, a small open-source helper for switching Codex CLI and Codex Desktop accounts with isolated `CODEX_HOME` profiles.

## Why

This list catalogs AI development tools and already includes OpenAI Codex/Codex CLI entries. codex-profiles is a focused Codex workflow utility for safe profile and account switching.

## Validation

- Ran `git diff --check`

