### PR TITLE
Add NotFair — open-source Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Northflank](https://northflank.com/)** - A platform for deploying and running applications and AI workloads, with support for isolated, ephemeral environments for executing code and agents.
 
+**[NotFair](https://github.com/nowork-studio/NotFair)** - An open-source (MIT, ~2.9k stars) Claude Code plugin with agent skills for [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo), [Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads), and [Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads). Connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP for audits, keyword research, wasted-spend detection, and ad creative analysis directly from Claude Code.
+
 **[OctoMind](https://octomind.dev)** - An AI-powered platform for generating and maintaining browser-based end-to-end tests, integrated into CI/CD pipelines.
 
 **[Ogoron](https://www.everydev.ai/tools/ogoron)** - An AI testing platform that analyzes code changes and application architecture to generate and maintain API, UI, and mobile tests.


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great reference!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source (MIT) Claude Code plugin with ~2.9k stars. It adds agent skills for SEO work (keyword research, meta tags, schema markup, GEO optimization, content writing), Google Ads management (audits, wasted-spend detection, search-term cleanup, bid management), and Meta Ads analysis (ROAS, creative fatigue, audience overlap). It pulls live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — all from inside Claude Code.

I placed it alphabetically between Northflank and OctoMind in the Tools section, following the same format as the other entries.

Happy to adjust the wording, move it, or trim the description if you prefer a different style. Thanks again!