### PR TITLE
Add Future AGI to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Functionize](https://www.functionize.com/)** - An intelligent testing platform that uses AI/ML for creating, executing, and maintaining automated functional tests, particularly for web applications.
 
+**[Future AGI](https://github.com/future-agi/future-agi)** - An open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0.
+
 **[Fynix](https://fynix.ai)** - An AI coding assistant designed to help developers throughout the SDLC.
 
 **[Galileo AI](https://www.usegalileo.ai/)** - A text-to-UI platform for generating user interfaces from text prompts (currently waitlisted).


### PR DESCRIPTION
Adds [Future AGI](https://github.com/future-agi/future-agi) — an open-source platform to evaluate, trace, and guardrail LLM and agent applications with 70+ metrics and LLM-as-a-judge. Placed in the relevant evaluation/observability/tooling section to match the list's existing entries.