### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Traycer](https://traycer.ai)** - A VS Code extension for intelligent code change management with real-time analysis and automated reviews.
 
+**[Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory)** - Local-first memory lifecycle framework for AI coding agents with Rust CLI/TUI, SQLite/FTS recall, forgetting, audit, and adapter hooks.
+
 **[Trelent](https://trelent.net/)** - A VS Code extension for generating docstrings using proprietary AI models.
 
 **[tutti](https://github.com/nutthouse/tutti)** - Multi-agent orchestration CLI with config-driven workflows, git worktree isolation, and typed artifact flow between agents.


### PR DESCRIPTION
Adds Tree Ring Memory to the alphabetical tools list.

Tree Ring Memory is a framework-agnostic, local-first memory lifecycle framework for AI coding agents with a Rust CLI/TUI, SQLite/FTS recall, forgetting, audit, and adapter hooks.

Disclosure: I am affiliated with the project.

Validation:
- Checked for existing Tree Ring Memory PRs/issues in this repo.
- Confirmed the linked GitHub repo returns HTTP 200.
- Ran `git diff --check`.
- Kept the entry in alphabetical order near the other `Tr...` tools.

Thanks for maintaining this list.