### PR TITLE
Add CocoIndex Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[cmux](https://github.com/manaflow-ai/cmux)** - Open-source platform for running multiple coding agents in parallel.
 
+**[CocoIndex Code](https://github.com/cocoindex-io/cocoindex-code)** - AST/tree-sitter code search MCP server that indexes a codebase and returns compact, relevant snippets to reduce coding-agent context usage.
+
 **[Codacy](https://www.codacy.com/)** - An automated code quality and performance analysis platform that integrates with Git repositories.
 
 **[CodeAct](https://codeact.ai/)** - An AI-powered tool for advanced debugging, including multi-threading and concurrency analysis.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[cmux](https://github.com/manaflow-ai/cmux)** - Open-source platform for running multiple coding agents in parallel.
 
-**[CocoIndex Code](https://github.com/cocoindex-io/cocoindex-code)** - AST/tree-sitter code search MCP server that indexes a codebase and returns compact, relevant snippets to reduce coding-agent context usage.
+**[CocoIndex Code](https://github.com/cocoindex-io/cocoindex-code)** - An Apache-2.0 code-search CLI and MCP server that uses Tree-sitter-based chunking and semantic search to retrieve code snippets for coding agents.
 
 **[Codacy](https://www.codacy.com/)** - An automated code quality and performance analysis platform that integrates with Git repositories.
 


### PR DESCRIPTION
Adds [CocoIndex Code](https://github.com/cocoindex-io/cocoindex-code) to the Tools list, in alphabetical order (between cmux and Codacy).

Open-source (Apache-2.0) AST / tree-sitter code search MCP server that indexes a codebase and returns compact, relevant snippets to reduce coding-agent context usage. Python, ~2.5k stars. Disclosure: I'm a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CocoIndex Code to the tools list.
  * Included its repository link and description as a code-search CLI and MCP server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->