### PR TITLE
Add usage — macOS menu bar quota monitor for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Unblocked](https://getunblocked.com/)** - An AI-powered code context and chat assistant with integration across GitHub, Slack, and Jira.
 
+**[usage](https://github.com/aqua5230/usage)** - macOS menu bar app that pins Claude Code and Codex quota to the screen, with burn-rate predictions and offline HTML usage reports, reading only local files with zero token overhead.
+
 **[v0.dev](https://v0.dev/)** - Vercel's AI-powered tool for generating React components from text descriptions, using shadcn/ui components.
 
 **[vibecraft](https://github.com/rayzhudev/vibecraft)** - An RTS-style workspace for managing AI coding agents.

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Unblocked](https://getunblocked.com/)** - An AI-powered code context and chat assistant with integration across GitHub, Slack, and Jira.
 
-**[usage](https://github.com/aqua5230/usage)** - macOS menu bar app that pins Claude Code and Codex quota to the screen, with burn-rate predictions and offline HTML usage reports, reading only local files with zero token overhead.
+**[usage](https://github.com/aqua5230/usage)** - A macOS menu bar and Windows system tray app that monitors Claude Code, Codex, and Antigravity quota, with burn rate estimates and locally generated usage reports.
 
 **[v0.dev](https://v0.dev/)** - Vercel's AI-powered tool for generating React components from text descriptions, using shadcn/ui components.
 


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) to the Tools list (alphabetical order, between Unblocked and v0.dev).

- Pins Claude Code and Codex quota (5-hour / weekly) to the macOS menu bar, with burn-rate predictions and offline HTML usage reports
- Never calls the Anthropic/OpenAI API; reads only local files, so monitoring adds zero token overhead
- Free, open source (AGPL-3.0), installable via `brew install --cask aqua5230/usage/usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)