### PR TITLE
Add Agent Island

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[aeon](https://github.com/aaronjmars/aeon)** - Autonomous agent framework that runs unattended on GitHub Actions; 90+ skills with quality scoring, self-healing, persistent memory, and reactive triggers.
 
+**[Agent Island](https://github.com/tristan666666/agent-island)** - Open-source status companion for Claude Code and Codex on macOS and Windows, with live session state, your-turn alerts, and local monitoring without an Agent Island account or product telemetry.
+
 **[agentbox](https://github.com/madarco/agentbox)** - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.
 
 **[agent-deck](https://github.com/asheshgoplani/agent-deck)** - Terminal session manager for AI coding agents.


### PR DESCRIPTION
## Summary

- Adds Agent Island in alphabetical order.
- Describes its current stable scope: local Claude Code/Codex status, your-turn alerts, macOS and Windows builds, no account, and no product telemetry.

## Disclosure

I am the maker of Agent Island.

## Current release verification

Refreshed for Agent Island v1.6.1 (released July 14, 2026). Agent Island is a free, MIT-licensed status companion for Claude Code and Codex on macOS and Windows. It shows live session state and your-turn alerts while keeping monitoring local, with no Agent Island account or product telemetry.

- Release: https://github.com/tristan666666/agent-island/releases/tag/v1.6.1
- Launch video: https://github.com/tristan666666/agent-island/blob/main/docs/media/agentisland-1.6.1-launch-en.mp4
- Product demo GIF: https://github.com/tristan666666/agent-island/blob/main/docs/media/launch.gif

Disclosure: I maintain Agent Island.