### PR TITLE
Add Find MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[FauxPilot](https://github.com/fauxpilot/fauxpilot)** - An open-source code completion server compatible with CodeGen.
 
+**[Find MCP](https://github.com/agentage/find-mcp)** - An MCP server for discovering other MCP servers, searching 17,000+ entries synced from the official MCP registry via remote Streamable HTTP or stdio.
+
 **[Fine](https://fine.dev/)** - An AI Dev Environment for automating mundane work, integrating with GitHub, Sentry, and Linear for context-aware answers and automated CI/CD.
 
 **[ForgeCode](https://forgecode.dev/)** - A CLI-based AI coding harness with multi-agent workflows, flexible model selection, custom agents, and codebase context tools for terminal-driven development.


### PR DESCRIPTION
Adds Find MCP to the `## 📚 Tools` list, alphabetically placed between FauxPilot and Fine, matching the existing `**[Name](url)** - description.` format.

- Find MCP: an MCP server for discovering other MCP servers. Searches the agentage MCP Catalog - 17,000+ servers synced from the official MCP registry (registry.modelcontextprotocol.io).
- GitHub: https://github.com/agentage/find-mcp
- npm: `@agentage/find-mcp` (stdio: `npx -y @agentage/find-mcp`)
- Remote: Streamable HTTP at https://catalog.agentage.io/mcp (no auth needed for search)
- Official MCP registry entry: `io.agentage/find-mcp`
- Web UI: https://catalog.agentage.io/mcp

It's OSS (MIT-style license, public repo), published on npm, and listed in the official MCP registry - these are adoption/validation signals for your screening.

Disclosure: I maintain Find MCP.