### PR TITLE
Add Constitution Lint Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[constellagent](https://github.com/owengretzinger/constellagent)** - macOS app for running multiple AI agents with their own terminal, editor, and git worktree.
 
+**[Constitution Lint Action](https://github.com/joeyycli/constitution-lint-action)** - A GitHub Action and pre-commit hook that lints CLAUDE.md-style AI agent constitution files for missing operational guardrails (authority order, injection-defense, spend limits, escalation path, secrets handling), catching gaps in CI before an unattended coding agent runs into them.
+
 **[Continue](https://continue.dev/)** - An open-source autopilot for software development that integrates with VS Code and JetBrains, allowing customizable LLM integration for code generation, editing, and debugging.
 
 **[CoPaw](https://github.com/agentscope-ai/CoPaw)** - Your Personal AI Assistant.


### PR DESCRIPTION
Adds Constitution Lint Action, alphabetically placed between Conduit8 and Continue.

[constitution-lint-action](https://github.com/joeyycli/constitution-lint-action) is a GitHub Action and pre-commit hook that lints `CLAUDE.md`-style AI agent constitution files for missing operational guardrails: authority order, injection-defense, spend limits, escalation path, secrets handling, ledger discipline, self-modification guard, and whether the state files it references actually exist. It is directly related to AI-assisted developer workflows: it validates the rules file that governs an autonomous coding agent's own behavior, so a gap is caught in CI instead of at 3am by an unattended agent.

Zero dependencies (single stdlib-only Python script), no duplicate entry exists in the list.
