### PR TITLE
Add agent-cost-guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[agentbox](https://github.com/madarco/agentbox)** - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.
 
-**[agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails)** - Framework-native budget limits and circuit breakers for CrewAI, AutoGen, and LangGraph agents. Enforces per-call token limits and cumulative cost budgets without manual monitoring.
+**[agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails)** - Python budget tracking and circuit-breaker middleware with adapters for CrewAI, AutoGen/AG2, and LangGraph; checks estimated tokens before calls and records actual token cost after responses.
 
 **[agent-deck](https://github.com/asheshgoplani/agent-deck)** - Terminal session manager for AI coding agents.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[agentbox](https://github.com/madarco/agentbox)** - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.
 
-**[agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails)** - Framework-native budget limits and circuit breakers for CrewAI, AutoGen, and LangGraph agents. Enforces per-run token caps and cost thresholds without manual monitoring.
+**[agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails)** - Framework-native budget limits and circuit breakers for CrewAI, AutoGen, and LangGraph agents. Enforces per-call token limits and cumulative cost budgets without manual monitoring.
 
 **[agent-deck](https://github.com/asheshgoplani/agent-deck)** - Terminal session manager for AI coding agents.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[agentbox](https://github.com/madarco/agentbox)** - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.
 
+**[agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails)** - Framework-native budget limits and circuit breakers for CrewAI, AutoGen, and LangGraph agents. Enforces per-run token caps and cost thresholds without manual monitoring.
+
 **[agent-deck](https://github.com/asheshgoplani/agent-deck)** - Terminal session manager for AI coding agents.
 
 **[agent-kanban](https://github.com/saltbo/agent-kanban)** - Agent-first kanban board with leader-worker model, cryptographic agent identity, and multi-runtime support (Claude Code, Codex, Gemini CLI).


### PR DESCRIPTION
Adds [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) — framework-native budget limits and circuit breakers for CrewAI, AutoGen, and LangGraph agents. Enforces per-run token caps and cost thresholds without manual monitoring. Alphabetically placed between agentbox and agent-deck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the `agent-cost-guardrails` tool entry.
  * Documented Python budget tracking and circuit-breaker support for CrewAI, AutoGen/AG2, and LangGraph.
  * Clarified pre-call token estimation and post-response token-cost recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->