### PR TITLE
Add notabene

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Northflank](https://northflank.com/)** - A platform for deploying and running applications and AI workloads, with support for isolated, ephemeral environments for executing code and agents.
 
-**[notabene](https://github.com/z29k/notabene)** - Renders a repo's Markdown/MDX as a navigable docs site with anchored, Google-Docs-style comments; an agent reads the committed comment store, applies the feedback as source edits, resolves the threads and journals what changed.
+**[notabene](https://github.com/z29k/notabene)** - Renders repository Markdown and MDX as a navigable documentation site with anchored comments, storing comments and journals in git-readable JSON alongside a protocol agents can follow to propose or apply the corresponding edits to the Markdown source.
 
 **[Nova](https://www.trynova.ai/)** - A CI bot that adds actions like summaries and tests to new pull requests.
 

--- a/README.md
+++ b/README.md
@@ -600,6 +600,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Northflank](https://northflank.com/)** - A platform for deploying and running applications and AI workloads, with support for isolated, ephemeral environments for executing code and agents.
 
+**[notabene](https://github.com/z29k/notabene)** - Renders a repo's Markdown/MDX as a navigable docs site with anchored, Google-Docs-style comments; an agent reads the committed comment store, applies the feedback as source edits, resolves the threads and journals what changed.
+
 **[Nova](https://www.trynova.ai/)** - A CI bot that adds actions like summaries and tests to new pull requests.
 
 **[nullclaw](https://github.com/nullclaw/nullclaw)** - Fastest, smallest, and fully autonomous AI assistant infrastructure.


### PR DESCRIPTION
Adds [notabene](https://github.com/z29k/notabene) to the tools list.

notabene renders a repo's Markdown/MDX as a navigable docs site where reviewers leave anchored, Google-Docs-style comments directly on the rendered text. The comments are committed as JSON alongside the docs, so a coding agent reads the open ones, applies the feedback as source edits, resolves the threads and writes a journal entry explaining what changed and why. The reviewer never has to verbalise the edit, and the whole round-trip stays in git.

Against the contributing guidelines:
- Developer-workflow tool (documentation review, agent-applied edits) — not a generic AI product
- Inserted in alphabetical order, between **Northflank** and **Nova**
- Uses the existing `**[Tool Name](link)** - Description.` format
- Neutral, concrete description; no promotional language
- Public repository link; MIT; published on npm as `@z29k/notabene`; docs at https://z29k.github.io/notabene/
- Checked for duplicates — not currently listed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the Notabene AI development tool to the tools list, including its repository link and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->