### PR TITLE
Update Agent Island for v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[aeon](https://github.com/aaronjmars/aeon)** - Autonomous agent framework that runs unattended on GitHub Actions; 90+ skills with quality scoring, self-healing, persistent memory, and reactive triggers.
 
-**[Agent Island](https://github.com/tristan666666/agent-island)** - Open-source status companion for Claude Code and Codex on macOS and Windows, with live session state, your-turn alerts, and local monitoring without an Agent Island account or product telemetry.
+**[Agent Island](https://github.com/tristan666666/agent-island)** - Free, MIT-licensed native companion for Claude, Codex, Gemini, Grok, and Cursor, combining local session status, your-turn alerts, and provider usage views without an Agent Island account or product telemetry.
 
 **[agentbox](https://github.com/madarco/agentbox)** - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.
 


### PR DESCRIPTION
## Summary

Updates the existing Agent Island description for [https://github.com/tristan666666/agent-island/releases/tag/v2.1.1](https://github.com/tristan666666/agent-island/releases/tag/v2.1.1): support for Claude, Codex, Gemini, Grok, and Cursor, with local session status, your-turn alerts, and provider usage views.

This is a factual refresh of an existing entry. I maintain Agent Island.