### PR TITLE
Add MyMCPTools (MCP server directory with liveness checks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[mux](https://github.com/coder/mux)** - A desktop app for isolated, parallel agentic development.
 
+**[MyMCPTools](https://mymcptools.com/)** - A searchable directory of 2,726 MCP servers that also ships as an MCP server, so an agent can find a server and check that it is actually reachable before you wire it into a config. The 44 servers exposing a remote endpoint are re-probed for reachability, latency, and tool-schema drift; local/stdio entries are labelled unprobeable rather than given an invented uptime figure.
+
 **[nanobot](https://github.com/HKUDS/nanobot)** - Ultra-lightweight personal AI assistant.
 
 **[nanoclaw](https://github.com/gavrielc/nanoclaw)** - Lightweight alternative to OpenClaw that runs in Apple containers for security.


### PR DESCRIPTION
Adds one entry, in alphabetical position between `mux` and `nanobot`, using the existing `**[Tool Name](URL)** - Description.` format.

**Developer use case:** picking an MCP server today means reading a README and hoping. MyMCPTools catalogs 2,726 of them and exposes the catalog as an MCP server (`search_mcp_servers`, `get_mcp_server`, `get_server_status`, `get_server_history`, `list_server_incidents`, `list_schema_drift`, `list_categories`, `get_catalog_stats`), so the check happens in-session before anything lands in a config file. Remote Streamable HTTP, no API key.

This is adjacent to [Find MCP](https://github.com/agentage/find-mcp), already in the list — that one searches the official registry; this one adds liveness and schema-drift state on top of the catalog.

**On the numbers, stated the unflattering way:** of the 2,726 entries only **44** expose a remote endpoint that can be probed at all; the other 98% are local/stdio servers. Those are labelled unprobeable rather than shown with a made-up uptime percentage. Of the 44 probeable, 5 were serving at the last sweep, 38 require auth, 1 was down. I would rather you see that ratio in the PR than discover it after merging.

Verified live tonight: `initialize` → `serverInfo.name mymcptools`, `protocolVersion 2025-06-18`; `tools/list` → the 8 tools above; `get_catalog_stats` → `total: 2726`, `probed_last_24h: 2726`. https://mymcptools.com/ returns 200.

**Disclosure:** I maintain MyMCPTools. Trim the description or close it if it is not what you want in the list.
