### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[assistant](https://github.com/kcosr/assistant)** - Panel-based personal assistant with a plugin architecture for productivity workflows.
 
+**[Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent)** - A local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Includes 56 built-in tools for browser, filesystem, git, memory, and vision, MCP support, a five-layer local memory system, and a React and ink terminal interface. Available for macOS, Linux, and Windows.
+
 **[Atomist](https://atomist.com/)** - A platform that enables automatic code modification and refactoring through "code transformations."
 
 **[Augment Code](https://www.augmentcode.com)** - An AI-powered developer platform for professional engineers and large codebases, with Auggie CLI for terminal-based coding, semantic codebase understanding, resumable sessions, sub-agents, and CI/CD integration.


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent, thanks for this great list, our team would be thrilled if you added us.

This PR adds one entry, **Atomic Agent**, in alphabetical order between `assistant` and `Atomist`, using the existing `**[Tool Name](url)** - Brief description.` format.

**What it is:** a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a llama.cpp fork, so there is no account or API key required to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, a five-layer local memory system, and a terminal interface built on React and ink. Works on macOS, Linux, and Windows.

Install:

```
curl -fsSL https://atomicagent.io/install | sh
```

Links:
- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT, ~2k stars, actively maintained)
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

One note in the interest of full transparency: the repo is about 4 months old. It is active though, at roughly 2k stars, and maintained by the AtomicBot-ai organization, which ships several established projects.

I kept the description neutral and focused on concrete developer-facing capabilities per the contributing guidelines, and put the extra links here in the PR rather than in the list row. Happy to trim the entry, reword it, or move it if you'd prefer something shorter. Thanks for considering it!
