### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Safurai](https://www.safurai.com/)** - An AI coding assistant.
 
+**[SandBase CLI](https://github.com/sandbaseai/cli)** - An Apache-2.0 CLI and MCP bridge that connects 17+ coding-agent clients to a hosted catalog of 2,000+ models and APIs through six discovery and execution tools.
+
 **[scion](https://github.com/GoogleCloudPlatform/scion)** - Multi-agent orchestration testbed that runs AI agents in parallel isolated containers with separate workspaces, dynamic coordination, and normalized telemetry.
 
 **[SeaGOAT](https://kantord.github.io/SeaGOAT/latest/)** - A local semantic codebase search tool that uses vector embeddings for context-aware code search.


### PR DESCRIPTION
## What

Adds SandBase CLI to the alphabetized AI development tools list.

## Why

SandBase CLI is an Apache-2.0 CLI and MCP bridge for coding-agent clients. It provides six tools for discovering, inspecting, invoking, and tracking calls to a hosted catalog of 2,000+ models and APIs.

The published `@sandbaseai/cli` package recorded 1,776 downloads in the latest completed monthly reporting window and 109 in the latest completed week.

## Validation

- Entry is placed alphabetically between Safurai and scion
- Public GitHub URL is accessible
- `git diff --check` passes

Disclosure: I am affiliated with SandBase. AI assistance was used to prepare this contribution.