### PR TITLE
Add aGiTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[agenttrace](https://github.com/luoyuctl/agenttrace)** - A local-first TUI for inspecting AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs, surfacing cost, cache usage, failures, latency, anomalies, health gates, and diffs.
 
+**[aGiTrack](https://github.com/core-aix/agitrack)** - Terminal wrapper for Claude Code, Codex, and OpenCode that turns each agent turn into a git commit, recording the prompt, model, and token cost in the commit message, with a local dashboard over the resulting history.
+
 **[AGX](https://github.com/ramarlina/agx)** - Local-first agent orchestrator with parallel execution, wake-work-sleep checkpointing, and human-in-the-loop gates.
 
 **[AI2SQL](https://www.ai2sql.io/)** - An AI-powered SQL query builder that converts natural language descriptions into SQL queries and offers optimization.


### PR DESCRIPTION
Adds aGiTrack in alphabetical order (between `agenttrace` and `AGX`), using the existing `**[Tool Name](url)** - Description.` format.

Disclosure: I'm the author.

aGiTrack is an open-source (Apache-2.0) terminal tool that runs Claude Code, Codex, or OpenCode and commits each agent turn to git automatically, recording the prompt, model, and that turn's token counts in the commit message, plus a local dashboard over the resulting history. It fits the list's scope as a developer-workflow tool for AI-assisted coding; the description is neutral and links to the public repository.