### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,8 @@ This comprehensive list showcases the latest and greatest AI-powered development
 
 **[Safurai](https://www.safurai.com/)** - An AI coding assistant.
 
+**[SandBase CLI](https://github.com/sandbaseai/cli)** - An open-source CLI and MCP bridge that routes requests across 2,000+ AI models and APIs, with support for 25 AI clients, six MCP tools, OAuth, and rollback.
+
 **[scion](https://github.com/GoogleCloudPlatform/scion)** - Multi-agent orchestration testbed that runs AI agents in parallel isolated containers with separate workspaces, dynamic coordination, and normalized telemetry.
 
 **[SeaGOAT](https://kantord.github.io/SeaGOAT/latest/)** - A local semantic codebase search tool that uses vector embeddings for context-aware code search.


### PR DESCRIPTION
Adds SandBase CLI to the alphabetized AI development tools list.

- Canonical repository: https://github.com/sandbaseai/cli
- Open-source CLI/MCP bridge for developer workflows; Apache-2.0 licensed.
- Routes requests across 2,000+ AI models and APIs; supports 25 AI clients, six MCP tools, OAuth, and rollback.

The entry follows the repository's concise format and developer-tool scope. I searched the README and found no existing SandBase entry. Claims were checked against the official repository and v0.1.17 catalog. Prepared with AI assistance; final entry manually reviewed.
